### PR TITLE
Clean up the FindByPsr4 class.

### DIFF
--- a/src/CommandFinder/FindByPsr4.php
+++ b/src/CommandFinder/FindByPsr4.php
@@ -76,29 +76,6 @@ class FindByPsr4
     }
 
     /**
-     * Get command classes.
-     *
-     * @return string[]
-     */
-    protected function getCommandClasses()
-    {
-        $classes = [];
-
-        foreach ($this->findPhpFiles() as $file) {
-            $className = StringBuilder::make($file)
-                ->replace($this->targetDir, '')
-                ->replace('/', '\\')
-                ->replace('.php', '')
-                ->prepend($this->nameSpacePrefix)
-                ->toString();
-
-            $classes[] = $className;
-        }
-
-        return $classes;
-    }
-
-    /**
      * Get php files by $baseDir.
      *
      * @return \Generator

--- a/src/CommandFinder/FindByPsr4.php
+++ b/src/CommandFinder/FindByPsr4.php
@@ -92,4 +92,21 @@ class FindByPsr4
             }
         }
     }
+
+    /**
+     * Convert to class name from file path.
+     *
+     * @param string $filePath
+     *
+     * @return string
+     */
+    protected function filePathToClassName(string $filePath)
+    {
+        return StringBuilder::make($filePath)
+            ->replace($this->targetDir, '')
+            ->replace('/', '\\')
+            ->replace('.php', '')
+            ->prepend($this->nameSpacePrefix)
+            ->toString();
+    }
 }

--- a/src/CommandFinder/FindByPsr4.php
+++ b/src/CommandFinder/FindByPsr4.php
@@ -62,14 +62,7 @@ class FindByPsr4
         $classes = [];
 
         foreach ($this->findPhpFiles() as $file) {
-            $className = StringBuilder::make($file)
-                ->replace($this->targetDir, '')
-                ->replace('/', '\\')
-                ->replace('.php', '')
-                ->prepend($this->nameSpacePrefix)
-                ->toString();
-
-            $classes[] = $className;
+            $classes[] = $this->filePathToClassName($file);
         }
 
         return $classes;

--- a/src/CommandFinder/FindByPsr4.php
+++ b/src/CommandFinder/FindByPsr4.php
@@ -61,8 +61,8 @@ class FindByPsr4
     {
         $classes = [];
 
-        foreach ($this->findPhpFiles() as $file) {
-            $classes[] = $this->filePathToClassName($file);
+        foreach ($this->findPhpFiles() as $filePath) {
+            $classes[] = $this->filePathToClassName($filePath);
         }
 
         return $classes;

--- a/src/CommandFinder/FindByPsr4.php
+++ b/src/CommandFinder/FindByPsr4.php
@@ -59,7 +59,20 @@ class FindByPsr4
      */
     public function getClasses()
     {
-        return $this->getCommandClasses();
+        $classes = [];
+
+        foreach ($this->findPhpFiles() as $file) {
+            $className = StringBuilder::make($file)
+                ->replace($this->targetDir, '')
+                ->replace('/', '\\')
+                ->replace('.php', '')
+                ->prepend($this->nameSpacePrefix)
+                ->toString();
+
+            $classes[] = $className;
+        }
+
+        return $classes;
     }
 
     /**


### PR DESCRIPTION
- Delete the `FindByPsr4::getCommandClasses()` method.
- Create and uses the `FindByPsr4::filePathToClassName()` method.